### PR TITLE
Allow user to append a title to note filenames

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,9 @@ let g:PlanTemplateDir = get(g:, 'PlanTemplatePath', "templates")
 let g:PlanDailiesDir = get(g:, 'PlanTemplatePath', "dailies")
 " generic notes dir relative to base dir
 let g:PlanNotesDir = get(g:, 'PlanTemplatePath', "notes")
+" allow user to append a title to default note file name
+" set to 0 or omit to disable adding a title to notes
+let g:PlanPromptForTitle = get(g:, 'PlanPromptForTitle', 1)
 ```
 
 ## See also

--- a/autoload/plan.vim
+++ b/autoload/plan.vim
@@ -8,6 +8,7 @@ let g:loaded_plan_vim = 1
 let s:dailiesDirectory = g:PlanBaseDir . "/" . g:PlanDailiesDir
 let s:notesDirectory = g:PlanBaseDir . "/" . g:PlanNotesDir
 let s:templatePath = g:PlanBaseDir . "/" . g:PlanTemplateDir
+let s:titleEnabled = g:PlanPromptForTitle
 
 function! plan#OpenDailyNote()
   let today = strftime("%Y%m%d")
@@ -26,13 +27,14 @@ function! plan#OpenDailyNote()
 endfunction
 
 function! plan#OpenNote()
-  let note = strftime("%Y%m%d-%H%M%S")
+  let msg = s:titleEnabled ? input('Enter note file title: ') : ''
+  let maybeTitle = msg ==  '' ? msg : "-" . msg
+  let dateTime = strftime("%Y%m%d-%H%M%S")
   call plan#EnsureDirectoryExists(s:notesDirectory)
-  let plan = s:notesDirectory . "/" . note . ".md"
+  let plan = s:notesDirectory . "/" . dateTime . maybeTitle . ".md"
   execute 'edit' plan
   call plan#setupBuffer()
 endfunction
-
 
 function! plan#MarkDone()
   call setline(line('.'), substitute(getline('.'), '- \[ \]', '- [x]', 'g'))

--- a/plugin/plan.vim
+++ b/plugin/plan.vim
@@ -3,7 +3,7 @@ let g:PlanBaseDir = get(g:, 'PlanBaseDir', $HOME . "/.plan")
 let g:PlanTemplateDir = get(g:, 'PlanTemplatePath', "templates")
 let g:PlanDailiesDir = get(g:, 'PlanDailiesDir', "dailies")
 let g:PlanNotesDir = get(g:, 'PlanNotesDir', "notes")
-
+let g:PlanPromptForTitle = get(g:, 'PlanPromptForTitle', 0)
 
 " command definitions
 command! PlanDaily :call plan#OpenDailyNote()


### PR DESCRIPTION
## Why

I find myself wanting to be able to scan the dir of notes and have them have semantic meaning.

This allows the user to optionally enter a title that will be appended to the note date time. So

```
notes/20230811-090049.md
```

Becomes optionally

```
notes/20230811-090049-my-cool-note.md
```

The user submitting an empty string returns just the date time.

## How

I'm learning vimscript finally lol. But yeah this is basic input, concat, and ternary.

## TODO

```[tasklist]
- [x] Determine if this breaks required compatibility with other programs
- [x] Should this be a configuration option?
```

## Meta

As noted above, I don't know if the note naming scehme is for compatibility reasons with other programs. Happy to close this if needs to remain the date time

Also, this changes the default behavior. Presumably we could make this a config option like base dir so users can opt in
