### PR TITLE
execute `:redraw!` after gathering todos

### DIFF
--- a/autoload/plan.vim
+++ b/autoload/plan.vim
@@ -98,4 +98,5 @@ endfunction
 function! plan#FindTodos()
   call plan#setupBuffer()
   execute ':silent lgrep! "\- \[ \]" ' . s:dailiesDirectory . ' ' . s:notesDirectory
+  execute ':redraw!'
 endfunction


### PR DESCRIPTION
in terminal vim I get a messed up screen after showing todos via `:PlanFindTodos` which only gets fixed after redrawing (either via `ctrl-l` or `:redraw!`). This however doesn't happen in MacVim so I'm not quite sure where the problem is.

As a workaround we just execute `:redraw!` after we look for todos. This works although I'd love to know if there is a better way.