### PR TITLE
fix asset importing

### DIFF
--- a/autoload/plan.vim
+++ b/autoload/plan.vim
@@ -135,8 +135,8 @@ function! plan#ImportAsset(full_file_path)
   let full_file_path = trim(a:full_file_path)
   let current_dir = expand("%:h")
   let filename = fnamemodify(full_file_path, ":t")
-  let current_asset_dir = current_dir . "/" . s:assetsDirectoryName
-  call plan#EnsureDirectoryExists(current_asset_dir)
-  let _ = system('cp -p ' . shellescape(full_file_path) . ' ' . current_asset_dir)
-  execute "normal! A" . '![](./' . s:assetsDirectoryName . '/' . filename . ')'
+  call plan#EnsureDirectoryExists(s:assetsDirectoryName)
+  let cmd = 'cp -p ' . shellescape(full_file_path) . ' ' . s:assetsDirectoryName
+  let _ = system(cmd)
+  execute "normal! A" . '![](' . s:assetsDirectoryName . '/' . filename . ')'
 endfunction


### PR DESCRIPTION
this broke when the asset directory was tied to the general plan
directory in https://github.com/mrtazz/vim-plan/pull/19
